### PR TITLE
Allow specifying DZ in querystring

### DIFF
--- a/www/main.js
+++ b/www/main.js
@@ -527,6 +527,15 @@ function setUTFURL()
 	);
 }
 
+function parseQueryStr() 
+{
+	var params = new URLSearchParams(document.location.search.substring(1));
+	var dz = params.get('dz');
+	if (!dz) return;
+	$('#datazone').val(dz);
+	searchForDatazone();
+}
+
 function setDefaults()
 {
 	/* Specified by user in URL. */
@@ -754,6 +763,11 @@ function searchForDatazone()
 		alert('This datazone is not in the correct format.');
 		return;		
 	}
+
+	var params = new URLSearchParams(location.search);
+	params.set('dz', p);
+
+	window.history.replaceState({}, '', `${location.pathname}?${params.toString()}${window.location.hash}`);
 
 	searchForDatazoneByFID(p, true);
 }
@@ -1191,7 +1205,7 @@ $( document ).ready(function()
 		currFilter = "_" + currentLayer.split("_")[1];
 	}
 	setTables();
-	
+	parseQueryStr();
   	var cityJumpHTML = "";
   	for (var i in cities)
   	{


### PR DESCRIPTION
Can't promise this'll 100% work with the live version but this should provide functionality most users would be happy with. When a datazone is searched for, its ID is stored in the query/search string of the URL in the format `?dz={ID}` and upon page loading after the DZ database has been loaded will parse the current URL searching for a DZ.